### PR TITLE
Update README.md with query parameters sample.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ curl -X POST 'localhost:7070/__set' \
 -d '{"when":{"method":"GET", "url":"dogs/**"}, "then": {"statusCode":200, "body":{"status": "cheerful"} }}'
 ```
 
+wildcard query param: (this one catches all the query parameters for `/dogs`, example: `/dogs?id=1&breed=bulldog`)
+```bash
+curl -X POST 'localhost:7070/__set' \
+-d '{"when":{"method":"GET", "url":"dogs?*"}, "then": {"statusCode":200, "body":{"status": "cheerful"} }}'
+```
+
 ### additional methods
 
 clear stubbed routes


### PR DESCRIPTION
Since i couldn't find the sample for url query parameters, i have tried couple of wildcards options provided and the below one works for my case. So proposing it to include in the readme.

```bash
curl -X POST 'localhost:7070/__set' \
-d '{"when":{"method":"*", "url":"facebook/debug_token?*"}, "then": {"statusCode":200, "body":{"data" : "{\"appId\":\"test-app\",\"application\":\"local\",\"expiresAt\":0,\"isValid\":true,\"issuedAt\":0,\"scopes\":[\"one\",\"two\"],\"userId\":\"prabhu\"}"   } }}'
```